### PR TITLE
Updated way to download the database if needed

### DIFF
--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -64,7 +64,7 @@ Installation
 
         Whichever ones you decide on, you need to put them under ~/databases/humandna and ~/databases/humanrna
         We will add more documentation on how to do other hosts later, but in general you can check out the configuration.rst file for
-        more information on how to configure the pipeline to use different indexes.
+        more information on how to configure the pipeline to use different indexes. NOTE: we will fix the database naming to the actual name on the downlaod  site instead of humandna/humanrna. 
 
           .. code-block:: bash
 


### PR DESCRIPTION
Updated way to download the database if needed. Still downloading Homo_sapiens_NCBI_build37.2.tar.gz, takes longer time, the nt database works. No need to downlaod nr database.
