### PR TITLE
Fixes an issue with host_map.pl 

### DIFF
--- a/usamriidPathDiscov/host_map/host_map.pl
+++ b/usamriidPathDiscov/host_map/host_map.pl
@@ -197,6 +197,9 @@ for (my $i = 0; $i < scalar(@mapper_db_list); $i++)
 			# get unmap reads
 			my $cmd="$path_scripts/fastq_extract_id.pl $hoh{$command}{\"R2\"} map_$j/R2.unmap.id > map_$j/R2.unmap.fastq";
 			print_system($cmd);	
+    
+            # The next time we map, likely that the input files are no longer wellpaired
+            $wellpaired=0;
 		}
 		# paired but not well paired
 		else


### PR DESCRIPTION
host_map.pl was not mapping correctly on subsequent mappings because input reads were coming from unmapped R1 and R2 from previous mapping. This means that R1 and R2 no longer had same amount of reads.

Closes #50
