### PR TITLE
Fixes an issue where cpuNum option was not being used

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -248,9 +248,8 @@ def run_path_discov(args):
 class TempDir(unittest.TestCase):
     def setUp(self):
         self.keep_temp_dir = False
-        if isdir(SCRATCH):
-            shutil.rmtree(SCRATCH)
-        os.makedirs(SCRATCH)
+        if not isdir(SCRATCH):
+            os.makedirs(SCRATCH)
         # Create temporary directory to run tests in inside scratch dir
         self.testdir = tempfile.mkdtemp(suffix=__name__, dir=SCRATCH)
         # Change directory into the testdir so accidental files will be

--- a/usamriidPathDiscov/helpers.py
+++ b/usamriidPathDiscov/helpers.py
@@ -390,7 +390,7 @@ def setup_shell_environment(config):
         os.pathsep + os.path.join(installdir,'step1') + \
         os.pathsep + os.environ['PATH']
 
-def setup_param(config):
+def setup_param(config, paramoutputfile):
     '''
     Setup sample.param file in installation directory
 
@@ -402,10 +402,9 @@ def setup_param(config):
     '''
     # Copy base sample.param.base to sample.param file
     baseFile = resource_filename(__name__, 'files/sample.param.base')
-    sampleParam = baseFile.replace('.base','')
-    shutil.copyfile(baseFile, sampleParam)
+    shutil.copyfile(baseFile, paramoutputfile)
     # replace some globals in the sample.param file such as db names
-    for line in fileinput.input(sampleParam, inplace=True, backup='.bak'):
+    for line in fileinput.input(paramoutputfile, inplace=True):
         line = re.sub(r'SEQPLATFORM',config['SEQUENCE_PLATFORM'], line.rstrip() )
         line = re.sub('NUMINST', config['NODE_NUM'], line.rstrip() )
         line = re.sub(r'HUMAN_DNA', config['human_dna'], line.rstrip())

--- a/usamriidPathDiscov/main.py
+++ b/usamriidPathDiscov/main.py
@@ -30,7 +30,6 @@ if R2:
 # Do all initial setup
 config = helpers.parse_config()
 helpers.setup_shell_environment(config)
-helpers.setup_param(config)
 
 # Setup initial inputs
 input_dir = join(project_dir, "input")
@@ -54,7 +53,8 @@ def createPram(output_file):
     '''
     Create param.txt inside projectdir/input
     '''
-    result = tasks.createParam(output_file)
+    config['NODE_NUM'] = str(options.cpuNum)
+    helpers.setup_param(config, output_file)
 
 def qa_outfile(input):
     ''' Generate quality_analysis output file for input file '''

--- a/usamriidPathDiscov/tasks.py
+++ b/usamriidPathDiscov/tasks.py
@@ -48,12 +48,6 @@ def copyDir(file_to_copy, file_copy):
     shutil.copytree(file_to_copy, file_copy)
     return
 
-def createParam(param_output):
-    # Gets config file as a file like object
-    fin = resource_stream(__name__, 'files/sample.param')
-    with open(param_output,'w') as fout:
-        fout.write(fin.read())
-
 def createQuality(input,output):
     """Check quality of the two fastq files
     Arguments:


### PR DESCRIPTION
param.txt now comes directly from sample.param.base file instead of having main copy sample.param.base -> sample.param then edit sample.param and then later copy sample.param to param.txt
